### PR TITLE
feat(canvas): change field render to canvas

### DIFF
--- a/src/assets/js/components/field.js
+++ b/src/assets/js/components/field.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import classNames from 'classnames';
+import drawSquare from '../helpers/draw-square';
 
 export default class Field extends Component {
 
@@ -10,6 +11,11 @@ export default class Field extends Component {
   }
 
   static defaultProps = {
+    pixel: 10,
+    colors: {
+      active: '#92E56C',
+      inactive: '#1D3507',
+    },
     row: {
       lines: []
     }
@@ -19,28 +25,18 @@ export default class Field extends Component {
     return this.props.row !== props.row;
   }
 
+  componentDidMount() {
+    let canvas = this.refs.container;
+    let {pixel, row, colors} = this.props;
+
+    drawSquare({pixel, canvas, row, colors});
+  }
+
   render = () => {
+    let size = this.props.pixel * this.props.row.get('lines').size;
+
     return (
-      <table className='c-field'>
-        <tbody>
-        { this.props.row.get('lines').map((row, i) => {
-          return (<tr key={i} className='c-field__line'>
-            {
-              row.map((line, x) => {
-                return (<td
-                  key={x}
-                  className={classNames({
-                    'c-field__item': true,
-                    'is-active': line.get('active')
-                  })}
-                >
-                </td>)
-              })
-            }
-          </tr>)
-      }) }
-      </tbody>
-    </table>
-    )
+      <canvas ref='container' width={size} height={size}></canvas>
+    );
   }
 }

--- a/src/assets/js/components/field.js
+++ b/src/assets/js/components/field.js
@@ -26,14 +26,14 @@ export default class Field extends Component {
   }
 
   componentDidMount() {
-    let canvas = this.refs.container;
-    let {pixel, row, colors} = this.props;
+    const canvas = this.refs.container;
+    const {pixel, row, colors} = this.props;
 
     drawSquare({pixel, canvas, row, colors});
   }
 
   render = () => {
-    let size = this.props.pixel * this.props.row.get('lines').size;
+    const size = this.props.pixel * this.props.row.get('lines').size;
 
     return (
       <canvas ref='container' width={size} height={size}></canvas>

--- a/src/assets/js/components/field.js
+++ b/src/assets/js/components/field.js
@@ -33,10 +33,13 @@ export default class Field extends Component {
   }
 
   render = () => {
-    const size = this.props.pixel * this.props.row.get('lines').size;
+    const { pixel, row } = this.props;
+    const size = pixel * row.get('lines').size;
 
     return (
-      <canvas ref='container' width={size} height={size}></canvas>
+      <div className='c-field'>
+        <canvas ref='container' width={size} height={size}></canvas>
+      </div>
     );
   }
 }

--- a/src/assets/js/helpers/draw-square.js
+++ b/src/assets/js/helpers/draw-square.js
@@ -1,0 +1,14 @@
+export default function({pixel, canvas, row, colors}) {
+  let lines = row.get('lines');
+  let context = canvas.getContext('2d');
+
+  lines.forEach((line, x) => line.forEach((item, y) => {
+    context.fillStyle = item.get('active') ? colors.active : colors.inactive;
+    context.fillRect(
+      x * pixel,
+      y * pixel,
+      pixel,
+      pixel
+    );
+  }));
+};

--- a/src/assets/js/helpers/draw-square.js
+++ b/src/assets/js/helpers/draw-square.js
@@ -1,6 +1,6 @@
 export default function({pixel, canvas, row, colors}) {
-  let lines = row.get('lines');
-  let context = canvas.getContext('2d');
+  const lines = row.get('lines');
+  const context = canvas.getContext('2d');
 
   lines.forEach((line, x) => line.forEach((item, y) => {
     context.fillStyle = item.get('active') ? colors.active : colors.inactive;

--- a/src/assets/sass/components/_button.sass
+++ b/src/assets/sass/components/_button.sass
@@ -20,4 +20,3 @@ $component-name: 'c-button'
   text-shadow: 0 0 5px $color-secondary-light
   &:active, &:hover
     background-color: darken($color-primary-dark, 3%)
-

--- a/src/assets/sass/components/_field.sass
+++ b/src/assets/sass/components/_field.sass
@@ -7,5 +7,5 @@ $component-name: 'c-field'
 .#{$component-name}
   margin: 0 5px
   +media('mobile')
-    margin: 0
+    margin: 0 -2.5px
     transform: scale(0.75)

--- a/src/assets/sass/components/_field.sass
+++ b/src/assets/sass/components/_field.sass
@@ -6,27 +6,7 @@ $component-name: 'c-field'
 $component-size: 13px
 
 .#{$component-name}
-  margin: 0 auto
-  display: inline-block
-
-.#{$component-name}__item
-    display: inline-block
-    width: $component-size
-    height: $component-size
-    background-color: $color-secondary // #97e381
-    box-shadow: -15px 5px 45px #0f0
-    &.is-active
-      background-color: $color-primary-dark
-    +media('mobile')
-      width: $component-size / 2
-      height: $component-size / 2
-
-.#{$component-name}__line
-  padding: 0
-  height: $component-size
-  display: block
-  overflow: hidden
-  line-height: $component-size / 2
+  margin: 0 5px
   +media('mobile')
-    line-height: 0
-    height: $component-size / 2
+    margin: 0
+    transform: scale(0.75)

--- a/src/assets/sass/components/_field.sass
+++ b/src/assets/sass/components/_field.sass
@@ -3,7 +3,6 @@
 // ***
 
 $component-name: 'c-field'
-$component-size: 13px
 
 .#{$component-name}
   margin: 0 5px

--- a/src/assets/sass/components/_options.sass
+++ b/src/assets/sass/components/_options.sass
@@ -11,11 +11,13 @@ $component-name: 'c-options'
 
 .#{$component-name}__button
   background-color: transparent
-  border: 1px solid $color-primary-light
-  padding: 3px 3px 2px 3px
-  margin: 3px
   cursor: pointer
   outline: 0
+  border: 0
+  padding: 0
   transition: 0.3s
   &:hover
     opacity: 0.5
+  > .c-field
+    padding: 3px
+    border: 1px solid $color-primary-light

--- a/src/assets/sass/components/_startup.sass
+++ b/src/assets/sass/components/_startup.sass
@@ -13,3 +13,9 @@ $component-name: 'c-startup'
 .#{$component-name}__button
   width: 190px
   margin: 20px auto
+  +media('mobile')
+    width: 100%
+    margin: 40px auto
+    > .c-button
+      width: 90%
+      padding: 40px 30px


### PR DESCRIPTION
This PR changes the field rendering to use canvas instead of a table.

It basically adds a `draw-square` and triggers the rendering when the component mounts.

Closes #21.
