### PR TITLE
fix(audio): Preload audio tracks

### DIFF
--- a/src/assets/js/components/app.js
+++ b/src/assets/js/components/app.js
@@ -6,7 +6,7 @@ import GameOver from './game-over';
 import Audio from './audio';
 import Analytics from './analytics';
 
-import getSound from '../helpers/get-sound';
+import { getSound, soundsSrc } from '../helpers/get-sound';
 
 export default class App extends Component {
 
@@ -21,7 +21,7 @@ export default class App extends Component {
           <Startup store={this.props.store} />
           <Game store={this.props.store} />
           <GameOver store={this.props.store} />
-          <Audio sound={getSound(this.props.store.get('sound'))} />
+          <Audio play={getSound(this.props.store.get('sound'))} sounds={soundsSrc} />
         </div>
     )
   }

--- a/src/assets/js/components/audio.js
+++ b/src/assets/js/components/audio.js
@@ -8,15 +8,19 @@ export default class Audio extends Component {
     super(props);
   }
 
+  playSound = () => {
+    this.props.play && this.refs[this.props.play].play();
+  }
+
   componentDidUpdate = () => {
-    this.refs.player.play();
+    this.playSound();
   }
 
   shouldComponentUpdate = (props) => {
-    let shouldUpdate = this.props.sound !== props.sound;
+    let shouldUpdate = this.props.play !== props.play;
 
     if (!shouldUpdate) {
-      this.refs.player.play();
+      this.playSound()
     }
 
     return shouldUpdate;
@@ -25,7 +29,9 @@ export default class Audio extends Component {
   render = () => {
     return (
         <div>
-          <audio ref='player' src={this.props.sound}></audio>
+          {this.props.sounds.map((sound) =>
+            <audio preload="auto" ref={sound} src={sound} key={sound}></audio>
+          )}
         </div>
     );
   }

--- a/src/assets/js/components/audio.js
+++ b/src/assets/js/components/audio.js
@@ -30,7 +30,7 @@ export default class Audio extends Component {
     return (
         <div>
           {this.props.sounds.map((sound) =>
-            <audio preload="auto" ref={sound} src={sound} key={sound}></audio>
+            <audio preload='auto' ref={sound} src={sound} key={sound}></audio>
           )}
         </div>
     );

--- a/src/assets/js/components/timer.js
+++ b/src/assets/js/components/timer.js
@@ -50,7 +50,7 @@ export default class Timer extends Component {
   }
 
   onCountDownDone = (data) => {
-    matchActions.overtime();
+    //matchActions.overtime();
   }
 
   render = () => {

--- a/src/assets/js/components/timer.js
+++ b/src/assets/js/components/timer.js
@@ -50,7 +50,7 @@ export default class Timer extends Component {
   }
 
   onCountDownDone = (data) => {
-    //matchActions.overtime();
+    matchActions.overtime();
   }
 
   render = () => {

--- a/src/assets/js/helpers/get-sound.js
+++ b/src/assets/js/helpers/get-sound.js
@@ -1,3 +1,5 @@
+import { values } from 'underscore';
+
 const sounds = {
   gameover: '/dist/assets/sounds/game-over.wav',
   missed: '/dist/assets/sounds/error.wav',
@@ -5,10 +7,7 @@ const sounds = {
   winner: '/dist/assets/sounds/winner.wav',
 }
 
-let soundsSrc = [];
-for (let src in sounds) {
-  soundsSrc.push(sounds[src]);
-}
+const soundsSrc = values(sounds);
 
 let getSound = (x) => sounds[x];
 

--- a/src/assets/js/helpers/get-sound.js
+++ b/src/assets/js/helpers/get-sound.js
@@ -5,6 +5,11 @@ const sounds = {
   winner: '/dist/assets/sounds/winner.wav',
 }
 
+let soundsSrc = [];
+for (let src in sounds) {
+  soundsSrc.push(sounds[src]);
+}
+
 let getSound = (x) => sounds[x];
 
-export default getSound;
+export { getSound, soundsSrc };


### PR DESCRIPTION
Prevents audio tag to continuosly loading the audio files from the
network, what brings an awful experience for players over slow networks.

:metal: 
